### PR TITLE
[BUGFIX] Create the database before the composer install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,15 @@ cache:
 
 before_install:
 - phpenv config-rm xdebug.ini
-
-install:
-- composer install
-
-before_script:
 - >
   echo;
   echo "Creating the database and importing the database schema";
   mysql -e "CREATE DATABASE ${PHPLIST_DATABASE_NAME};";
   mysql -u root -e "GRANT ALL ON ${PHPLIST_DATABASE_NAME}.* TO ${PHPLIST_DATABASE_USER}@''%'';";
   mysql ${PHPLIST_DATABASE_NAME} < vendor/phplist/phplist4-core/Database/Schema.sql;
+
+install:
+- composer install
 
 script:
 - >


### PR DESCRIPTION
Now the Travis build steps are in a different order to ensure the
following dependency chain does not break:

1. composer install calls the composer scripts
2. the composer script for clearing the cache requires a working
   Symfony systen
3. for production mode (including warming the production caches),
   a working MySQL database is required