### PR TITLE
[TASK] Test with both latest and oldest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: php
 
-matrix:
-  include:
-  - php: 7.0
-  - php: 7.1
-  - php: 7.2
+php:
+- 7.0
+- 7.1
+- 7.2
 
 services:
 - mysql
 
 env:
   global:
-  - PHPLIST_DATABASE_NAME=phplist
-  - PHPLIST_DATABASE_USER=travis
-  - PHPLIST_DATABASE_PASSWORD=''
+  - PHPLIST_DATABASE_NAME=phplist PHPLIST_DATABASE_USER=travis PHPLIST_DATABASE_PASSWORD=''
+  matrix:
+  - DEPENDENCIES=latest
+  - DEPENDENCIES=oldest
 
 notifications:
   slack:
@@ -33,7 +33,16 @@ before_install:
 - phpenv config-rm xdebug.ini
 
 install:
-- composer install
+- >
+  echo;
+  if [ "$DEPENDENCIES" = "latest" ]; then
+    echo "Installing the latest dependencies";
+    composer update --with-dependencies --prefer-stable --prefer-dist
+  else
+    echo "Installing the lowest dependencies";
+    composer update --with-dependencies --prefer-stable --prefer-dist --prefer-lowest
+  fi;
+  composer show;
 
 before_script:
 - >

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2.2",
-        "squizlabs/php_codesniffer": "^3.0.1",
+        "squizlabs/php_codesniffer": "^3.0.0",
         "phpstan/phpstan": "^0.7.0",
+        "nette/caching": "^2.5.0 || ^3.0.0",
+        "nikic/php-parser": "^3.0.0",
         "phpmd/phpmd": "^2.6.0"
     },
     "autoload": {


### PR DESCRIPTION
This ensures that our dependency versions given in the composer.json always
provide a working set of packages.

Also make the dependencies more lenient and provide explicit minimal versions
for some indirect dependencies.