### PR TITLE
[FEATURE] Use the testdox printer for PHPUnit

### DIFF
--- a/Configuration/PHPUnit/phpunit.xml
+++ b/Configuration/PHPUnit/phpunit.xml
@@ -2,8 +2,8 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
-         backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         printerClass="rpkamp\FancyTestdoxPrinter"
          colors="true"
          bootstrap="../../vendor/autoload.php"
 >

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5.0",
+        "rpkamp/fancy-testdox-printer": "^0.2.2",
         "squizlabs/php_codesniffer": "^3.2.0",
         "phpstan/phpstan": "^0.7.0",
         "nette/caching": "^2.5.0 || ^3.0.0",


### PR DESCRIPTION
Also update the PHPUnit schema URL to the latest version and drop
a redundant attribute from the PHPUnit configuration file.