### PR TITLE
[TASK] Use static:: instead of self::

### DIFF
--- a/Tests/Integration/Composer/ScriptsTest.php
+++ b/Tests/Integration/Composer/ScriptsTest.php
@@ -17,7 +17,7 @@ class ScriptsTest extends TestCase
      */
     public function webDirectoryHasBeenCreated()
     {
-        self::assertDirectoryExists($this->getAbsoluteWebDirectoryPath());
+        static::assertDirectoryExists($this->getAbsoluteWebDirectoryPath());
     }
 
     /**
@@ -48,7 +48,7 @@ class ScriptsTest extends TestCase
      */
     public function webDirectoryFilesExist(string $fileName)
     {
-        self::assertFileExists($this->getAbsoluteWebDirectoryPath() . $fileName);
+        static::assertFileExists($this->getAbsoluteWebDirectoryPath() . $fileName);
     }
 
     /**
@@ -56,7 +56,7 @@ class ScriptsTest extends TestCase
      */
     public function binariesDirectoryHasBeenCreated()
     {
-        self::assertDirectoryExists($this->getAbsoluteBinariesDirectoryPath());
+        static::assertDirectoryExists($this->getAbsoluteBinariesDirectoryPath());
     }
 
     /**
@@ -84,7 +84,7 @@ class ScriptsTest extends TestCase
      */
     public function binariesExist(string $fileName)
     {
-        self::assertFileExists($this->getAbsoluteBinariesDirectoryPath() . $fileName);
+        static::assertFileExists($this->getAbsoluteBinariesDirectoryPath() . $fileName);
     }
 
     /**
@@ -100,7 +100,7 @@ class ScriptsTest extends TestCase
      */
     public function bundleConfigurationFileExists()
     {
-        self::assertFileExists($this->getBundleConfigurationFilePath());
+        static::assertFileExists($this->getBundleConfigurationFilePath());
     }
 
     /**
@@ -122,7 +122,7 @@ class ScriptsTest extends TestCase
     {
         $fileContents = file_get_contents($this->getBundleConfigurationFilePath());
 
-        self::assertContains($bundleClassName, $fileContents);
+        static::assertContains($bundleClassName, $fileContents);
     }
 
     /**
@@ -138,7 +138,7 @@ class ScriptsTest extends TestCase
      */
     public function moduleRoutesConfigurationFileExists()
     {
-        self::assertFileExists($this->getModuleRoutesConfigurationFilePath());
+        static::assertFileExists($this->getModuleRoutesConfigurationFilePath());
     }
 
     /**
@@ -146,7 +146,7 @@ class ScriptsTest extends TestCase
      */
     public function parametersConfigurationFileExists()
     {
-        self::assertFileExists(dirname(__DIR__, 3) . '/Configuration/parameters.yml');
+        static::assertFileExists(dirname(__DIR__, 3) . '/Configuration/parameters.yml');
     }
 
     /**
@@ -154,6 +154,6 @@ class ScriptsTest extends TestCase
      */
     public function modulesConfigurationFileExists()
     {
-        self::assertFileExists(dirname(__DIR__, 3) . '/Configuration/config_modules.yml');
+        static::assertFileExists(dirname(__DIR__, 3) . '/Configuration/config_modules.yml');
     }
 }

--- a/Tests/System/ApplicationBundle/PhpListApplicationBundleTest.php
+++ b/Tests/System/ApplicationBundle/PhpListApplicationBundleTest.php
@@ -53,7 +53,7 @@ class PhpListApplicationBundleTest extends TestCase
 
         $response = $this->httpClient->get('/', ['base_uri' => $this->getBaseUrl()]);
 
-        self::assertSame(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -67,6 +67,6 @@ class PhpListApplicationBundleTest extends TestCase
 
         $response = $this->httpClient->get('/', ['base_uri' => $this->getBaseUrl()]);
 
-        self::assertNotEmpty($response->getBody()->getContents());
+        static::assertNotEmpty($response->getBody()->getContents());
     }
 }


### PR DESCRIPTION
This will allow for subclasses to overwrite methods and constants and hence
is the current recommended practice.