### PR TITLE
[BUGFIX] Remove the roave/security-advisories dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,7 @@
     "require": {
         "php": "~7.0.0 || ~7.1.0 || ~7.2.0",
 
-        "phplist/core": "4.0.x-dev",
-
-        "roave/security-advisories": "dev-master"
+        "phplist/core": "4.0.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5.6",


### PR DESCRIPTION
1. This dependency should only be a dev dependency, not a production
   dependency, so that is kicks in when we update packages.
2. This package is intended to be used only for projects and distributions,
   not for libraries (like this package).