### PR TITLE
introduced ci with github workflows for builds and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: phpList Build
+on: [push, pull_request]
+jobs:
+  main:
+    name: phpList Base Dist on PHP ${{ matrix.php-versions }}, with dist ${{ matrix.dependencies }} [Build, Test]
+    runs-on: ubuntu-latest
+    env:
+      DB_DATABASE: phplist
+      DB_USERNAME: root
+      DB_PASSWORD: phplist
+      BROADCAST_DRIVER: log  
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: false
+          MYSQL_ROOT_PASSWORD: ${{ env.DB_PASSWORD }}
+          MYSQL_DATABASE: ${{ env.DB_DATABASE }}
+        ports:
+          - 3306/tcp
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        dependencies: ['latest', 'oldest']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, dom, fileinfo, mysql
+          coverage: xdebug #optional
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
+      - name: Verify MySQL connection on host
+        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -u${{ env.DB_USERNAME }} -p${{ env.DB_PASSWORD }} -e "SHOW DATABASES"
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          # Use composer.json for key, if composer.lock is not committed.
+          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install the latest dependencies
+        run: composer update --with-dependencies --prefer-stable --prefer-dist
+        if: ${{ matrix.dependencies }} == "latest"
+      - name: Install lowest dependencies from 
+        run: composer update --with-dependencies --prefer-stable --prefer-dist --prefer-lowest
+        if: ${{ matrix.dependencies }} == "oldest"
+      - name: Set up database schema
+        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -u${{ env.DB_USERNAME }} -p${{ env.DB_PASSWORD }} ${{ env.DB_DATABASE }} < vendor/phplist/core/resources/Database/Schema.sql
+      - name: Validating composer.json
+        run: composer validate --no-check-all --no-check-lock --strict;
+      - name: Linting all php files
+        run: find src/ tests/ public/ -name ''*.php'' -print0 | xargs -0 -n 1 -P 4 php -l; php -l;
+      - name: Run integration tests with phpunit
+        run: vendor/bin/phpunit tests/Integration/
+      - name: Running the system tests
+        run: vendor/bin/phpunit tests/Integration/;
+      - name: Running static analysis
+        run: vendor/bin/phpstan analyse -l 5 src/ tests/;
+      - name: Running PHPMD
+        run: vendor/bin/phpmd src/ text vendor/phplist/core/config/PHPMD/rules.xml;
+      - name: Running PHP_CodeSniffer
+        run: vendor/bin/phpcs --standard=vendor/phplist/core/config/PhpCodeSniffer/ src/ tests/;


### PR DESCRIPTION
### Summary
Introduced github actions (workflows) for use as main ci pipeline for builds and testing.

### Integration tests
Builds pass on php versions `php versions 7.0`, `7.1` & `7.2`. `composer.json` specifies those are the only candidates for installation, so fixing the codebase to support `php 7.3` and `php 7.4` would be addressed in a separate PR.


REF : https://github.com/Fenn-CS/web-frontend/actions/runs/543271033