### PR TITLE
Updated dep php_codesniffer, added support for php 7.0 - php 7.0 | php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "source": "https://github.com/phpList/web-frontend"
     },
     "require": {
-        "php": "~7.0.0 || ~7.1.0 || ~7.2.0",
-
+        "php": "^7.0|^8.0",
         "phplist/core": "4.0.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "phpunit/phpunit": "^6.5.6",
         "phpunit/phpunit-mock-objects": "^5.0.6",
         "guzzlehttp/guzzle": "^6.3.0",
-        "squizlabs/php_codesniffer": "^3.2.0",
+        "squizlabs/php_codesniffer": "^3.5.8",
         "phpstan/phpstan": "^0.7.0",
         "nette/caching": "^2.5.0 || ^3.0.0",
         "nikic/php-parser": "^3.1.0",


### PR DESCRIPTION
### Summary
* Support for `php 7.0 - php 7.0 | php 8.0` made possible (via composer.json update)
* `phpcs` was failing due to some errors from it's previous version not supported by newer php stables, `phpcs` has been updated to latest stable `phpcs 3.5.8`

See : https://github.com/Fenn-CS/web-frontend/actions/runs/551577898

### Unit and Integration Tests

All tests pass!


### Code style

Linting checks succeed.